### PR TITLE
Fix style - part of content outside range

### DIFF
--- a/src/sass/_style.scss
+++ b/src/sass/_style.scss
@@ -34,7 +34,7 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
     display: flex;
     width: 50vw;
     height: 50vh;
-    margin: 12rem auto; 
+    margin: 8rem auto; 
     justify-content: center; 
     padding: 0 50px;
 }
@@ -125,8 +125,7 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
   line-height: 163%;
   font-family: 'Montserrat', sans-serif;
   font-weight: 800; 
-  text-align: left;
-  margin-bottom: 129px;
+  text-align: left; 
 }
 
 .compass-modal {
@@ -137,7 +136,7 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
   padding: 40px 20px;              
   border-radius: 20px; 
   margin: 0 auto;
-  margin-top: 15rem;
+  margin-top: 12rem;
   max-width: 45%;
 }
 


### PR DESCRIPTION
### SCSS File Updates

#### File: `_style.scss`
**Adjustments to Component Layout and Sizing:**
- **`.content`**: Reduced top margin from `12rem` to `8rem` for better vertical alignment.
- **`.text-welcome`**: Removed the bottom margin (`129px`) for a more cohesive layout.
- **`.compass-modal`**: Adjusted top margin from `15rem` to `12rem` for improved spacing across screen sizes.

Fix for balanced alignment between the two halves of the content area.