### PR TITLE
mobile adpt

### DIFF
--- a/src/sass/_style.scss
+++ b/src/sass/_style.scss
@@ -515,6 +515,35 @@ select.form-control {
   max-width: 820px !important;
   min-width: 510px;
 }
+@media (max-width: 1199.98px) {
+  .col-md-10 {
+    flex: 0 0 100%;
+    max-width: 100%;    
+}
+
+.bg-primary-400{
+  padding: 7rem 0;
+}
+
+.pgn__hyperlink{
+  display: none;
+}
+
+.content { 
+  width: 100%; 
+  max-height: 100vh;
+  margin-top: 0;
+  padding: 0 50px;
+}
+
+.compass-modal {
+  margin-top: 0;
+}
+
+.logo {
+  display: none;
+}
+}
 
 
 @media (min-width: 1024px) {
@@ -553,6 +582,12 @@ select.form-control {
     margin-bottom: 0;
   }
 }
+@media (max-width: 576px) {
+.mw-xs {
+  max-width: 464px !important;
+  min-width: auto;
+}
+}
 
 // Smaller than Extra Small (Mobile Screens)
 @media (max-width: 464px) {
@@ -575,6 +610,7 @@ select.form-control {
       min-width: unset !important;
     }
   }
+
 }
 
 .table-striped tbody tr:nth-of-type(odd) {


### PR DESCRIPTION
Mobile Adaptation Changes:
Media Queries:

_For screens smaller than 1199.98px:_
Modified .col-md-10 to ensure it takes full width (100%).
Added padding for .bg-primary-400 (7rem).
Hid .pgn__hyperlink and .logo.
Adjusted .content to ensure it takes full width, has no margin, and includes padding.
Set .compass-modal margin-top to 0 for consistency.

_For screens with a width of 1024px or higher:_
Adjusted styles for select.form-control to maintain a consistent margin.

_For screens smaller than 576px:_
Added .mw-xs class with specific width settings (max-width: 464px).

_For screens smaller than 464px:_
Ensured select.form-control has unset minimum width.
